### PR TITLE
chore: bump .net to 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,18 @@ on:
       - main
   workflow_call:
 
+env:
+  DOTNET_VERSION: 9.x
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET Core SDK 6.0.x
-        uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@v4
+      - name: Setup .NET Core SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: ${{ env.DOTNET_VERSION }}
       - uses: actions/cache@v3
         with:
           path: ~/.nuget/packages

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ jobs:
       new_version_with_v: ${{ steps.release-version.outputs.new_version_with_v }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,12 @@ on:
           - minor
           - major
   pull_request:
-    branch: [main]
+    branches: [main]
     types: [closed]
 
 env:
   NUGET_ENABLE_LEGACY_CSPROJ_PACK: true
+  DOTNET_VERSION: 9.x
 
 jobs:
   bump-version:
@@ -37,12 +38,12 @@ jobs:
 
     steps:
       # get the code setup the build
-      - uses: actions/checkout@v3
-      
-      - name: Setup .NET Core SDK 6.0.x
-        uses: actions/setup-dotnet@v2.1.0
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET Core SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Install dependencies
         run: dotnet restore -r linux-x64 Aesir.Hermod/Aesir.Hermod.csproj
@@ -72,7 +73,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Push New Tag (temp manual because actions-ecosystem/action-push-tag@v1 is broken)
         run: |
           message='${{needs.bump-version.outputs.new_version_with_v}}: Sha #${{ github.sha }}'

--- a/Aesir.Hermod.Tests/Aesir.Hermod.Tests.csproj
+++ b/Aesir.Hermod.Tests/Aesir.Hermod.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Aesir.Hermod/Aesir.Hermod.csproj
+++ b/Aesir.Hermod/Aesir.Hermod.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
-    <PackageReference Include="RabbitMQ.Client" Version="6.4.0"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0"/>
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0"/>
   </ItemGroup>
 </Project>

--- a/Aesir.Hermod/Bus/BusWorker.cs
+++ b/Aesir.Hermod/Bus/BusWorker.cs
@@ -21,7 +21,10 @@ internal class BusWorker : IHostedService
         sp.GetLogger<BusWorker>().LogDebug("Performed initialization of all required services.");
     }
 
-    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await _bus.InitializeAsync(cancellationToken);
+    }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/Aesir.Hermod/Bus/Interfaces/IMessagingBus.cs
+++ b/Aesir.Hermod/Bus/Interfaces/IMessagingBus.cs
@@ -8,6 +8,7 @@ namespace Aesir.Hermod.Bus.Interfaces;
 /// </summary>
 internal interface IMessagingBus
 {
+    Task InitializeAsync(CancellationToken ct);
     IModel GetChannel();
     void RegisterResponseExpected(string correlationId, Action<object?> func, Type ExpectedResult);
     ExpectedResponse? GetExpectedResponse(string correlationId);


### PR DESCRIPTION
This pull request updates the project to target .NET 9, upgrades all major dependencies to their latest versions, and modernizes the GitHub Actions workflows to use the latest action versions and configuration patterns. It also improves the initialization process for the messaging bus by making it asynchronous, ensuring that connections are properly established before use.

**.NET and Dependency Upgrades:**
- Updated target framework to `net9.0` in both `Aesir.Hermod` and `Aesir.Hermod.Tests` projects, and upgraded all NuGet package dependencies to their latest compatible versions. [[1]](diffhunk://#diff-c7a13c29381d234d4c19a3c2a220f92503894316b58399224e528e3a00ab3230L3-R12) [[2]](diffhunk://#diff-38c3ea6de50989bfe960dd0f3bbe5a1e87fb6e69c397bd1d0719b8aebdb1ee47L4-R19)

**GitHub Actions Workflow Modernization:**
- Updated all workflow files to use the latest versions of `actions/checkout` and `actions/setup-dotnet`, and centralized the .NET version via an environment variable (`DOTNET_VERSION: 9.x`). Also fixed a minor typo in the `release.yml` workflow trigger. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R9-R20) [[2]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L26-R26) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R20) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L40-R46) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L75-R76)

**Messaging Bus Initialization Improvements:**
- Changed the `IMessagingBus` interface and its implementations to support asynchronous initialization via a new `InitializeAsync` method, ensuring connections (e.g., to RabbitMQ) are established before use. [[1]](diffhunk://#diff-427d97dfbfbe300d9447a769df945710b6f2836cb8f8d5d5fb9bb9285722b3aaR11) [[2]](diffhunk://#diff-a8e0180eb9c2cb01562dbd6889b969502761c94c5c7953f186427716cc75020aL24-R27) [[3]](diffhunk://#diff-a3f1765e4167b1d2ac0d50ea4c0167c1ac83fe335b1e03fe1ee8b9db8324550fL15-R29)
- Refactored the RabbitMQ bus to delay connection creation until `InitializeAsync` is called, and made the retry logic asynchronous. Also, `GetChannel()` now throws an exception if the bus is not initialized. [[1]](diffhunk://#diff-a3f1765e4167b1d2ac0d50ea4c0167c1ac83fe335b1e03fe1ee8b9db8324550fL15-R29) [[2]](diffhunk://#diff-a3f1765e4167b1d2ac0d50ea4c0167c1ac83fe335b1e03fe1ee8b9db8324550fL39-R52)