### PR TITLE
chore: net10 bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 
 env:
-  DOTNET_VERSION: 9.x
+  DOTNET_VERSION: 10.x
 
 jobs:
   build-and-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   NUGET_ENABLE_LEGACY_CSPROJ_PACK: true
-  DOTNET_VERSION: 9.x
+  DOTNET_VERSION: 10.x
 
 jobs:
   bump-version:

--- a/Aesir.Hermod.Tests/Aesir.Hermod.Tests.csproj
+++ b/Aesir.Hermod.Tests/Aesir.Hermod.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">

--- a/Aesir.Hermod/Aesir.Hermod.csproj
+++ b/Aesir.Hermod/Aesir.Hermod.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0"/>
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0"/>
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
This pull request upgrades the project from .NET 9 to .NET 10, updating all relevant configurations, dependencies, and workflows to ensure compatibility. It also updates several Microsoft package dependencies to their latest major versions.

**.NET 10 Upgrade:**

* Updated `TargetFramework` to `net10.0` in both `Aesir.Hermod.csproj` and `Aesir.Hermod.Tests.csproj` to target .NET 10.0. [[1]](diffhunk://#diff-c7a13c29381d234d4c19a3c2a220f92503894316b58399224e528e3a00ab3230L3-R12) [[2]](diffhunk://#diff-38c3ea6de50989bfe960dd0f3bbe5a1e87fb6e69c397bd1d0719b8aebdb1ee47L4-R12)
* Added/updated `global.json` to specify the .NET SDK version 10.0.100 with `rollForward` set to `latestFeature`.
* Updated the `DOTNET_VERSION` environment variable from `9.x` to `10.x` in both `.github/workflows/build.yml` and `.github/workflows/release.yml` to ensure CI uses the correct SDK version. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L10-R10) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R20)

**Dependency Updates:**

* Upgraded Microsoft package dependencies in `Aesir.Hermod.csproj` from version 9.0.0 to 10.0.0 for `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Hosting.Abstractions`, and `Microsoft.Extensions.Logging`.
* Updated `Microsoft.NET.Test.Sdk` in `Aesir.Hermod.Tests.csproj` from version 17.12.0 to 17.13.0.