### PR TITLE
fix: bug in lazy init of config builder

### DIFF
--- a/Aesir.Hermod.Tests/Bus/RabbitMqBusTests.cs
+++ b/Aesir.Hermod.Tests/Bus/RabbitMqBusTests.cs
@@ -14,10 +14,10 @@ public class RabbitMqBusTests
     {
         var connFactory = new Mock<IConnectionFactory>();
         var connection = new Mock<IConnection>();
-        var model = new Mock<IModel>();
+        var channel = new Mock<IChannel>();
 
-        connection.Setup(c => c.CreateModel()).Returns(model.Object);
-        connFactory.Setup(c => c.CreateConnection()).Returns(connection.Object);
+        connection.Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync(channel.Object);
+        connFactory.Setup(c => c.CreateConnectionAsync(It.IsAny<CancellationToken>())).ReturnsAsync(connection.Object);
 
         var bus = new RabbitMqBus(new ServiceCollection().BuildServiceProvider(), connFactory.Object);
         return bus;

--- a/Aesir.Hermod/Aesir.Hermod.csproj
+++ b/Aesir.Hermod/Aesir.Hermod.csproj
@@ -8,7 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1"/>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1"/>
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0"/>
+    <PackageReference Include="RabbitMQ.Client" Version="7.2.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1"/>
   </ItemGroup>
 </Project>
+
+

--- a/Aesir.Hermod/Bus/Interfaces/IMessagingBus.cs
+++ b/Aesir.Hermod/Bus/Interfaces/IMessagingBus.cs
@@ -9,7 +9,7 @@ namespace Aesir.Hermod.Bus.Interfaces;
 internal interface IMessagingBus
 {
     Task InitializeAsync(CancellationToken ct);
-    IModel GetChannel();
+    IChannel GetChannel();
     void RegisterResponseExpected(string correlationId, Action<object?> func, Type ExpectedResult);
     ExpectedResponse? GetExpectedResponse(string correlationId);
     void RemoveCorrelationCallback(string correlationId);

--- a/Aesir.Hermod/Configuration/ConfigurationBuilder.cs
+++ b/Aesir.Hermod/Configuration/ConfigurationBuilder.cs
@@ -25,7 +25,7 @@ public class ConfigurationBuilder : IConfigurationBuilder
     private readonly EndpointConsumerFactory _endpointConsumerFactory;
     private readonly IServiceProvider _sp;
     private readonly ILogger<ConfigurationBuilder> _logger;
-    private readonly MessageProducer _producer;
+    private MessageProducer? _producer;
     internal BusOptions BusOptions { get; set; } = new();
     internal ProducerOptions ProducerOptions { get; set; } = new();
 
@@ -37,7 +37,6 @@ public class ConfigurationBuilder : IConfigurationBuilder
         _endpointConsumerFactory = new EndpointConsumerFactory();
         _sp = sp;
         _logger = sp.GetLogger<ConfigurationBuilder>();
-        _producer = new MessageProducer(sp, ProducerOptions.ResponseTimeout);
     }
 
     /// <summary>
@@ -75,10 +74,10 @@ public class ConfigurationBuilder : IConfigurationBuilder
         new MessageReceiver(_endpointConsumerFactory, sp);
 
     internal IMessageProducer ConfigureProducer(IServiceProvider sp) =>
-        _producer;
+        _producer ??= new MessageProducer(sp, ProducerOptions.ResponseTimeout);
 
     internal IInternalMessageProducer ConfigureInternalProducer(IServiceProvider sp) =>
-        _producer;
+        _producer ??= new MessageProducer(sp, ProducerOptions.ResponseTimeout);
 
     /// <summary>
     /// Registers an <see cref="IConsumer{T}"/> to be used for the specified queue.


### PR DESCRIPTION
This pull request updates the codebase to support the asynchronous RabbitMQ.Client 7.x API, replacing synchronous methods and types with their asynchronous counterparts. The main changes include updating the messaging bus and producer logic to use `IChannel` and async methods, adjusting consumer registration, and updating dependencies.

**RabbitMQ API modernization:**

* Replaced all usage of `IModel` with `IChannel` throughout the codebase, including the `IMessagingBus` interface and `RabbitMqBus` implementation. All synchronous RabbitMQ calls (e.g., `CreateModel`, `ExchangeDeclare`, `QueueDeclare`, `BasicPublish`, `BasicConsume`) are now replaced by their async equivalents (e.g., `CreateChannelAsync`, `ExchangeDeclareAsync`, `QueueDeclareAsync`, `BasicPublishAsync`, `BasicConsumeAsync`). [[1]](diffhunk://#diff-427d97dfbfbe300d9447a769df945710b6f2836cb8f8d5d5fb9bb9285722b3aaL12-R12) [[2]](diffhunk://#diff-a3f1765e4167b1d2ac0d50ea4c0167c1ac83fe335b1e03fe1ee8b9db8324550fL15-R15) [[3]](diffhunk://#diff-a3f1765e4167b1d2ac0d50ea4c0167c1ac83fe335b1e03fe1ee8b9db8324550fL29-R29) [[4]](diffhunk://#diff-a3f1765e4167b1d2ac0d50ea4c0167c1ac83fe335b1e03fe1ee8b9db8324550fL40-R41) [[5]](diffhunk://#diff-a3f1765e4167b1d2ac0d50ea4c0167c1ac83fe335b1e03fe1ee8b9db8324550fL52-R53) [[6]](diffhunk://#diff-e214a296acfcc6e89efff16a3ca581c21cee90933c0fe96ebf3a86bac91f3d78L30-R35) [[7]](diffhunk://#diff-e214a296acfcc6e89efff16a3ca581c21cee90933c0fe96ebf3a86bac91f3d78L56-R56) [[8]](diffhunk://#diff-e214a296acfcc6e89efff16a3ca581c21cee90933c0fe96ebf3a86bac91f3d78L67-R73) [[9]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L116-R122) [[10]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L135-R154) [[11]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L170-R177) [[12]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L188-R196) [[13]](diffhunk://#diff-3d97d032fbd4115da44b86962debad34861a6bc601b32fb701eb8e673de24694L17-R20)

* Updated consumer registration to use `AsyncEventingBasicConsumer` and its async event handler, ensuring compatibility with the new async RabbitMQ client.

**Dependency and compatibility updates:**

* Upgraded the `RabbitMQ.Client` NuGet package from version 6.8.1 to 7.2.0 and updated `Microsoft.Extensions.Logging` to 10.0.1 for compatibility with the new async API.

**Internal refactoring and safety:**

* Refactored `MessageProducer` to use the new `BasicProperties` class instead of `IBasicProperties`, and updated its methods to use async RabbitMQ calls. [[1]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L41-R47) [[2]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L116-R122) [[3]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L135-R154) [[4]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L170-R177) [[5]](diffhunk://#diff-4729383f50dd414e448a2b38e0ce77242f376363aebc6b970f9613e1d56c0cc9L188-R196)
* Changed the instantiation logic in `ConfigurationBuilder` to lazily initialize the `MessageProducer`, improving resource management and ensuring it is only created when needed. [[1]](diffhunk://#diff-1d91088ad47bc065be4d877fbf2944104ce1f50f9dcdd039d373c80f61c1d97fL28-R28) [[2]](diffhunk://#diff-1d91088ad47bc065be4d877fbf2944104ce1f50f9dcdd039d373c80f61c1d97fL40) [[3]](diffhunk://#diff-1d91088ad47bc065be4d877fbf2944104ce1f50f9dcdd039d373c80f61c1d97fL78-R80)